### PR TITLE
Change markupsafe version to fix breaking change

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,8 @@ RUN pip3 install --no-cache-dir \
 	dbt-spark[ODBC]~=0.20.2 \
 	pyodbc~=4.0.32
 
+RUN pip3 install --force-reinstall MarkupSafe==2.0.1
+
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT [ "/entrypoint.sh" ]


### PR DESCRIPTION
[Markupsafe](https://pypi.org/project/MarkupSafe/) recently released a minor version with breaking changes, resulting in the following error when attempting to install `dbt-core`: `ImportError: cannot import name 'soft_unicode' from 'markupsafe'`. Short term solution is to manually downgrade markupsafe.

Refer to [#4745](https://github.com/dbt-labs/dbt-core/issues/4745) for more info.